### PR TITLE
fix: search for Bastion

### DIFF
--- a/handler/bastion.go
+++ b/handler/bastion.go
@@ -30,6 +30,10 @@ func getBastion() string {
 				Name:   aws.String("tag:service"),
 				Values: []string{"bastion"},
 			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"running"},
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes a bug where the search for bastion would find old bastion instances that have been stopped but not yet terminated (by an ASG instance refresh for example). This fix makes sure that we only search for running bastions.
